### PR TITLE
BUG-2020 : Allow parsing JSON from input stream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ deploy:
   script: "mvn deploy -B -DskipTests --settings ci-tools/common/maven-settings.xml"
   skip_cleanup: true
   on:
-    branch: master
+    branch: BUG-2020__isot_http-vastaukset

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ deploy:
   script: "mvn deploy -B -DskipTests --settings ci-tools/common/maven-settings.xml"
   skip_cleanup: true
   on:
-    branch: BUG-2020__isot_http-vastaukset
+    branch: master

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>sharedutils</artifactId>
-    <version>5.4-SNAPSHOT</version>
+    <version>5.5-SNAPSHOT</version>
 
     <name>Sharedutils</name>
 

--- a/src/main/java/fi/vm/sade/valinta/sharedutils/http/ExtractSuccessfullResponseFromStreamCallback.java
+++ b/src/main/java/fi/vm/sade/valinta/sharedutils/http/ExtractSuccessfullResponseFromStreamCallback.java
@@ -1,0 +1,126 @@
+package fi.vm.sade.valinta.sharedutils.http;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.htmlcleaner.CleanerProperties;
+import org.htmlcleaner.PrettyXmlSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.InvocationCallback;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class ExtractSuccessfullResponseFromStreamCallback<T> implements InvocationCallback<Response> {
+    private final static Logger LOG = LoggerFactory.getLogger(ExtractSuccessfullResponseFromStreamCallback.class);
+    private final String url;
+    private final Consumer<T> callback;
+    private final Consumer<Throwable> failureCallback;
+    private final Function<InputStream, T> extractor;
+
+    public ExtractSuccessfullResponseFromStreamCallback(final String url,
+                                                        final Consumer<T> callback,
+                                                        final Consumer<Throwable> failureCallback,
+                                                        final Function<InputStream, T> extractor) {
+        this.url = url;
+        this.callback = callback;
+        this.failureCallback = failureCallback;
+        this.extractor = extractor;
+    }
+
+    @Override
+    public void completed(Response response) {
+        if (response.getStatus() >= 300) {
+            String msg = String.format("%s HTTP %d", url, response.getStatus());
+            failureCallback.accept(new HttpExceptionWithResponse(msg, response));
+            return;
+        }
+        InputStream responseInputStream = new ByteArrayInputStream(new byte[]{});
+        try {
+            responseInputStream = readResponseAsInputStream(response);
+            T t = extractor.apply(responseInputStream);
+            try {
+                if (t == null) {
+                    String errorMessage = String.format("Saatiin null vastaus URLista '%s'", url);
+                    LOG.error(errorMessage);
+                    throw new RuntimeException(errorMessage);
+                }
+                callback.accept(t);
+            } catch (Exception e) {
+                LOG.error(
+                        "Asynkronisen kutsun ({}) paluuarvonkasittelija heitti poikkeuksen:\r\nRESPONSE {} ->\r\n{} {}",
+                        url,
+                        response.getStatus(),
+                        response.getMetadata().getFirst("Content-Type"),
+                        format(response, responseInputStream),
+                        e);
+                failureCallback.accept(e);
+            }
+        } catch (Exception e) {
+            LOG.error(
+                    "Gson deserialisointi epaonnistui onnistuneelle asynkroniselle palvelin kutsulle ({}), {}:\r\nRESPONSE {} {} ->\r\n{}",
+                    url, e.getMessage(), response.getStatus(),
+                    response.getMetadata().getFirst("Content-Type"),
+                    format(response, responseInputStream));
+            LOG.error("Gson deserialization throws", e);
+            try {
+                failureCallback.accept(e);
+            } catch (Exception ex) {
+                LOG.error(
+                        "Asynkronisen kutsun ({}) epaonnistuneesta sarjallistuksesta seuranneelle virheenkasittelijakutsusta lensi poikkeus: {}:\r\nRESPONSE {} {} ->\r\n{}",
+                        url, ex.getMessage(),
+                        response.getStatus(),
+                        response.getMetadata().getFirst("Content-Type"),
+                        format(response, responseInputStream));
+                LOG.error("failureCallback throws", ex);
+            }
+        }
+    }
+
+    private InputStream readResponseAsInputStream(final Response response) {
+        return (InputStream) response.getEntity();
+    }
+
+    @Override
+    public void failed(Throwable throwable) {
+        try {
+            failureCallback.accept(throwable);
+        } catch (Exception ex) {
+            LOG.error("Epaonnistuneen asynkronisen kutsun (" + url + ") virheenkasittelija heitti poikkeuksen", ex);
+        }
+    }
+
+    private String format(Response response, InputStream json) {
+        try {
+            if (isTextHtml(response)) {
+                CleanerProperties cp = new CleanerProperties();
+                cp.setAddNewlineToHeadAndBody(false);
+                cp.setOmitHtmlEnvelope(true);
+                try {
+                    return new PrettyXmlSerializer(cp).getAsString(IOUtils.toString(json, "UTF-8"));
+                } catch (Exception ex) {
+                    return StringUtils.substring(IOUtils.toString(json, "UTF-8"), 0, 250);
+                }
+            } else {
+                return StringUtils.substring(IOUtils.toString(json, "UTF-8"), 0, 250);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private boolean isTextHtml(Response response) {
+        try {
+            return Optional.of(response.getMetadata().getFirst("Content-Type"))
+                .orElse(new Object()).toString()
+                .contains(MediaType.TEXT_HTML);
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/fi/vm/sade/valinta/sharedutils/http/GsonResponseInpuStreamCallback.java
+++ b/src/main/java/fi/vm/sade/valinta/sharedutils/http/GsonResponseInpuStreamCallback.java
@@ -1,0 +1,27 @@
+package fi.vm.sade.valinta.sharedutils.http;
+
+import com.google.gson.Gson;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class GsonResponseInpuStreamCallback<T> extends ExtractSuccessfullResponseFromStreamCallback<T> {
+    static <T>Function<InputStream, T> jsonExtractor(Gson gson, Type type) {
+        return responseStream -> {
+            try {
+                return gson.fromJson(new InputStreamReader(responseStream), type);
+            } finally {
+                IOUtils.closeQuietly(responseStream);
+            }
+        };
+    }
+
+    public GsonResponseInpuStreamCallback(Gson gson, String url, Consumer<T> callback, Consumer<Throwable> failureCallback, Type type) {
+        super(url, callback, failureCallback, jsonExtractor(gson, type));
+    }
+}

--- a/src/main/java/fi/vm/sade/valinta/sharedutils/http/HttpResource.java
+++ b/src/main/java/fi/vm/sade/valinta/sharedutils/http/HttpResource.java
@@ -3,9 +3,9 @@ package fi.vm.sade.valinta.sharedutils.http;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 
+import io.reactivex.Observable;
 import org.apache.cxf.jaxrs.client.JAXRSClientFactoryBean;
 import org.apache.cxf.jaxrs.client.WebClient;
-import io.reactivex.Observable;
 
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
@@ -48,6 +48,8 @@ public interface HttpResource {
     <T, A> Observable<T> getAsObservableLazily(String path, final Type type, Entity<A> getBody);
 
     <T> Observable<T> getAsObservableLazily(String path, final Type type, Function<WebClient, WebClient> paramsHeadersAndStuff);
+
+    <T> Observable<T> getAsObservableLazilyWithInputStream(String path, Type type, Function<WebClient, WebClient> paramsHeadersAndStuff);
 
     <T> Observable<T> getAsObservableLazily(String path, Function<String, T> extractor, Function<WebClient, WebClient> paramsHeadersAndStuff);
 


### PR DESCRIPTION
Handling large HTTP responses does not work if
we put the entire response into a String.

Stringiin ei mahdu enempää kuin n. 2 gigatavua tavaraa => on fiksumpaa passata Gsonille suoraan

Jos tapa osoittautuu toimivaksi, kaikki operaatiot voisi konvertoida käyttämään sitä.