### PR TITLE
OY-5547 Poistetaan CAS-riippuvuus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>fi.vm.sade.valintaperusteet</groupId>
     <artifactId>sharedutils</artifactId>
-    <version>8.2-SNAPSHOT</version>
+    <version>8.3-SNAPSHOT</version>
 
     <name>Sharedutils</name>
 
@@ -57,11 +57,6 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
             <version>6.5.10</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apereo.cas.client</groupId>
-            <artifactId>cas-client-core</artifactId>
-            <version>4.1.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/test/java/fi/vm/sade/valinta/sharedutils/FakeAuthenticationInitialiser.java
+++ b/src/test/java/fi/vm/sade/valinta/sharedutils/FakeAuthenticationInitialiser.java
@@ -1,6 +1,5 @@
 package fi.vm.sade.valinta.sharedutils;
 
-import org.apereo.cas.client.authentication.SimplePrincipal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.TestingAuthenticationToken;

--- a/src/test/java/fi/vm/sade/valinta/sharedutils/SimplePrincipal.java
+++ b/src/test/java/fi/vm/sade/valinta/sharedutils/SimplePrincipal.java
@@ -1,0 +1,36 @@
+package fi.vm.sade.valinta.sharedutils;
+
+import java.security.Principal;
+import java.util.Objects;
+
+public class SimplePrincipal implements Principal {
+    private final String name;
+
+    public SimplePrincipal(final String name) {
+        if (name == null) {
+            throw new IllegalArgumentException("name cannot be null.");
+        }
+        this.name = name;
+    }
+
+    @Override
+    public final String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SimplePrincipal that)) return false;
+        return Objects.equals(name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(name);
+    }
+}


### PR DESCRIPTION
Riippuvuutta käytetään vain yhden POJOn tuomiseen. Sen sijaan lisätään koodiin suoraan minimaalinen Principal-toteutus.